### PR TITLE
Downgrade to NETCore 2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,4 @@ dbconfig.json
 masterconfig.json
 logs
 Railgun.pdf
+Published/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Shared.Music"]
-	path = Shared.Music
-	url = https://github.com/ComputerMaster1st/Shared.Music.git

--- a/Railgun.sln
+++ b/Railgun.sln
@@ -1,17 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TreeDiagram", "TreeDiagram\TreeDiagram.csproj", "{A5739A19-A24B-44A2-81FD-0ED64255C926}"
+VisualStudioVersion = 15.0.28307.168
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TreeDiagram", "TreeDiagram\TreeDiagram.csproj", "{A5739A19-A24B-44A2-81FD-0ED64255C926}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Railgun", "Railgun\Railgun.csproj", "{0AD77693-5A9C-445F-924F-30944A500810}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared.Music", "Shared.Music", "{2BDBB056-70E8-4C1A-8094-0C0DBBCCABE3}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{72F758FD-FE26-48EF-9540-14FF7F571178}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioChord", "Shared.Music\src\AudioChord\AudioChord.csproj", "{393CE48D-39D1-4FB4-AF2B-A19AAE19FB71}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioChord.Parsers", "Shared.Music\src\AudioChord.Parsers\AudioChord.Parsers.csproj", "{729F549A-00A3-429E-A551-FD0AE29308FC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Railgun", "Railgun\Railgun.csproj", "{0AD77693-5A9C-445F-924F-30944A500810}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,18 +13,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{361B5AD2-EE2A-48D9-8593-25BB2654E0F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{361B5AD2-EE2A-48D9-8593-25BB2654E0F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{361B5AD2-EE2A-48D9-8593-25BB2654E0F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{361B5AD2-EE2A-48D9-8593-25BB2654E0F5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4D6D5DFF-CCA6-4571-ADC7-DDCF4FBA6840}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4D6D5DFF-CCA6-4571-ADC7-DDCF4FBA6840}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4D6D5DFF-CCA6-4571-ADC7-DDCF4FBA6840}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4D6D5DFF-CCA6-4571-ADC7-DDCF4FBA6840}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B15A8668-4E34-4949-A289-AFA2F407A370}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B15A8668-4E34-4949-A289-AFA2F407A370}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B15A8668-4E34-4949-A289-AFA2F407A370}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B15A8668-4E34-4949-A289-AFA2F407A370}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A5739A19-A24B-44A2-81FD-0ED64255C926}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A5739A19-A24B-44A2-81FD-0ED64255C926}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A5739A19-A24B-44A2-81FD-0ED64255C926}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -39,19 +21,12 @@ Global
 		{0AD77693-5A9C-445F-924F-30944A500810}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0AD77693-5A9C-445F-924F-30944A500810}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0AD77693-5A9C-445F-924F-30944A500810}.Release|Any CPU.Build.0 = Release|Any CPU
-		{393CE48D-39D1-4FB4-AF2B-A19AAE19FB71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{393CE48D-39D1-4FB4-AF2B-A19AAE19FB71}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{393CE48D-39D1-4FB4-AF2B-A19AAE19FB71}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{393CE48D-39D1-4FB4-AF2B-A19AAE19FB71}.Release|Any CPU.Build.0 = Release|Any CPU
-		{729F549A-00A3-429E-A551-FD0AE29308FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{729F549A-00A3-429E-A551-FD0AE29308FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{729F549A-00A3-429E-A551-FD0AE29308FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{729F549A-00A3-429E-A551-FD0AE29308FC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{72F758FD-FE26-48EF-9540-14FF7F571178} = {2BDBB056-70E8-4C1A-8094-0C0DBBCCABE3}
-		{393CE48D-39D1-4FB4-AF2B-A19AAE19FB71} = {72F758FD-FE26-48EF-9540-14FF7F571178}
-		{729F549A-00A3-429E-A551-FD0AE29308FC} = {72F758FD-FE26-48EF-9540-14FF7F571178}
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D39AA090-3EBC-49A9-AF60-AEB35C162346}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/Railgun/Core/Initializer.cs
+++ b/Railgun/Core/Initializer.cs
@@ -82,7 +82,7 @@ namespace Railgun.Core
                         )
                     ).EnableSensitiveDataLogging().UseLazyLoadingProxies();
                 }, ServiceLifetime.Transient)
-                .AddSingleton(new MusicService(new MusicServiceConfig() {
+                .AddSingleton(new MusicService(new MusicServiceConfiguration() {
                     Hostname = mongoConfig.Hostname,
                     Username = mongoConfig.Username,
                     Password = mongoConfig.Password,

--- a/Railgun/Railgun.csproj
+++ b/Railgun/Railgun.csproj
@@ -7,7 +7,6 @@
         <LangVersion>7.2</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="AudioChord.Parsers" Version="1.0.1" />
         <PackageReference Include="CSharpScriptSerializer" Version="1.6.1" />
         <PackageReference Include="Discord.Net" Version="2.0.2-dev-01059" />
         <PackageReference Include="Google.Apis.YouTube.v3" Version="1.38.0.1488" />

--- a/Railgun/Railgun.csproj
+++ b/Railgun/Railgun.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,11 +7,11 @@
         <LangVersion>7.2</LangVersion>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="AudioChord.Parsers" Version="1.0.1" />
         <PackageReference Include="CSharpScriptSerializer" Version="1.6.1" />
         <PackageReference Include="Discord.Net" Version="2.0.2-dev-01059" />
         <PackageReference Include="Google.Apis.YouTube.v3" Version="1.38.0.1488" />
         <PackageReference Include="Discord.Addons.Finite.Commands" Version="0.2.0-dev-00034" />
-        <ProjectReference Include="..\Shared.Music\src\AudioChord.Parsers\AudioChord.Parsers.csproj" />
         <ProjectReference Include="..\TreeDiagram\TreeDiagram.csproj" />
     </ItemGroup>
 </Project>

--- a/TreeDiagram/TreeDiagram.csproj
+++ b/TreeDiagram/TreeDiagram.csproj
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="AudioChord" Version="1.0.4" />
+        <PackageReference Include="AudioChord" Version="1.0.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="2.2.2" />

--- a/TreeDiagram/TreeDiagram.csproj
+++ b/TreeDiagram/TreeDiagram.csproj
@@ -1,13 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netcoreapp2.2</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="AudioChord" Version="1.0.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="2.2.2" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
-        <ProjectReference Include="../Shared.Music/src/AudioChord/AudioChord.csproj" />
     </ItemGroup>
 </Project>

--- a/TreeDiagram/TreeDiagramContext.cs
+++ b/TreeDiagram/TreeDiagramContext.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using MongoDB.Bson;
 using TreeDiagram.Models.Server;
@@ -11,7 +11,7 @@ using TreeDiagram.Models.User;
 
 namespace TreeDiagram
 {
-	public sealed class TreeDiagramContext : DbContext
+    public sealed class TreeDiagramContext : DbContext
 	{
 		public DbSet<FilterCaps> FilterCapses { get; internal set; }
 		public DbSet<FilterUrl> FilterUrls { get; internal set; }
@@ -30,9 +30,9 @@ namespace TreeDiagram
 		public DbSet<UserCommand> UserCommands { get; internal set; }
 		public DbSet<UserMention> UserMentions { get; internal set; }
 
-		public TreeDiagramContext(DbContextOptions optionsBuilder) : base(optionsBuilder) { }
+        public TreeDiagramContext(DbContextOptions optionsBuilder) : base(optionsBuilder) => AppContext.SetSwitch("System.Net.Http.useSocketsHttpHandler", false);
 
-		protected override void OnModelCreating(ModelBuilder modelBuilder)
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
 		{
 			modelBuilder.Entity<ServerMusic>(x => {
 				x.Property(y => y.PlaylistId)

--- a/nuget.config
+++ b/nuget.config
@@ -3,5 +3,6 @@
  <packageSources>
     <add key="Discord.Net" value="https://www.myget.org/F/discord-net/api/v3/index.json" />
     <add key="FiniteReality" value="https://www.myget.org/F/finitereality/api/v3/index.json" />
+   <add key="CryoDev" value="http://51.15.0.129:5000/v3/index.json" />
  </packageSources>
 </configuration>

--- a/publish.bat
+++ b/publish.bat
@@ -1,1 +1,1 @@
-dotnet publish -o Published -c Release --self-contained -r ubuntu.18.04-x64
+dotnet publish -o Published -c Release

--- a/publish.sh
+++ b/publish.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-dotnet publish -o ~/Desktop/Railgun -c Release --self-contained -r ubuntu.18.04-x64
+dotnet publish -o ~/Desktop/Railgun -c Release


### PR DESCRIPTION
Due to receiving "Segmentation fault" from NETCore 3.0, we'll be downgrading to 2.2 as it is the latest stable & "Long-Term Support".